### PR TITLE
Ensure a specific nightly is used to run cargo-web

### DIFF
--- a/CargoWebAsset.js
+++ b/CargoWebAsset.js
@@ -7,6 +7,7 @@ const Asset = require( "parcel-bundler/src/Asset" );
 const path = require( "path" );
 
 const REQUIRED_CARGO_WEB = [0, 6, 2];
+const REQUIRED_NIGHTLY = "nightly-2018-07-11";
 
 class CargoWebAsset extends Asset {
     constructor( name, options ) {
@@ -116,9 +117,6 @@ class CargoWebAsset extends Asset {
 
         const dir = path.dirname( await config.resolve( this.name, ["Cargo.toml"] ) );
         const args = [
-            "run",
-            "nightly",
-            cargo_web_command,
             "build",
             "--target",
             "wasm32-unknown-unknown",
@@ -133,7 +131,7 @@ class CargoWebAsset extends Asset {
             stdio: ["ignore", "pipe", "pipe"]
         };
 
-        const rust_build = spawn( "rustup", args, opts );
+        const rust_build = spawn(cargo_web_command, args, opts);
         const rust_build_process = rust_build.childProcess;
 
         let artifact_wasm = null;
@@ -198,10 +196,11 @@ class CargoWebAsset extends Asset {
     }
 
     static async install_nightly() {
-        const rustup_show_output = await CargoWebAsset.exec( "rustup show" );
-        if( !rustup_show_output.includes( "nightly" ) ) {
-            await pipeSpawn( "rustup", ["update"] );
-            await pipeSpawn( "rustup", ["toolchain", "install", "nightly"] );
+        const rustup_show_output = await CargoWebAsset.exec("rustup show");
+        const activeToolchains = rustup_show_output.split(/^active toolchain$/m)[1];
+        if (!activeToolchains.includes(REQUIRED_NIGHTLY)) {
+            await pipeSpawn("rustup", ["update"]);
+            await pipeSpawn("rustup", ["override", "set", REQUIRED_NIGHTLY]);
         }
     }
 

--- a/CargoWebAsset.js
+++ b/CargoWebAsset.js
@@ -6,8 +6,8 @@ const pipeSpawn = require( "parcel-bundler/src/utils/pipeSpawn" );
 const Asset = require( "parcel-bundler/src/Asset" );
 const path = require( "path" );
 
-const REQUIRED_CARGO_WEB = [0, 6, 2];
-const REQUIRED_NIGHTLY = "nightly-2018-07-11";
+const REQUIRED_CARGO_WEB = [0, 6, 15];
+const REQUIRED_NIGHTLY = "nightly-2018-07-31";
 
 class CargoWebAsset extends Asset {
     constructor( name, options ) {

--- a/CargoWebAsset.js
+++ b/CargoWebAsset.js
@@ -198,7 +198,7 @@ class CargoWebAsset extends Asset {
     static async install_nightly() {
         const rustup_show_output = await CargoWebAsset.exec("rustup show");
         const activeToolchains = rustup_show_output.split(/^active toolchain$/m)[1];
-        if (!activeToolchains.includes(REQUIRED_NIGHTLY)) {
+        if (!activeToolchains || !activeToolchains.includes(REQUIRED_NIGHTLY)) {
             await pipeSpawn("rustup", ["update"]);
             await pipeSpawn("rustup", ["override", "set", REQUIRED_NIGHTLY]);
         }


### PR DESCRIPTION
I've run into several issues with wasm32-unknown-unknown and the default behaviour of installing the newest rust nightly:

- `stdweb` doesn't compile
- Debug symbols are not generated, making debugging and profiling nearly impossible (stack traces in Chrome only consist of `<WASM UNNAMED>`, for example)
- the chosen nightly "doesn't support components", leading to a cryptic error when cargo-web queries rustup for installed targets

For that reason, I created a fork where I can pin the plugin to a specific nightly using rustup directory overrides instead of using `rustup run nightly ...`. I found an older nightly through trial and error that doesn't have any of the mentioned issues, but I might have missed a newer one that is also fine. And this implies that you would need to maintain this known-good somewhat-recent nightly information.

Feel free to address this otherwise and reject this PR, I don't know how you feel about this design choice, I just needed the reliability for my own project.