### PR TITLE
Compile in release mode and remove nightly requirement

### DIFF
--- a/CargoWebAsset.js
+++ b/CargoWebAsset.js
@@ -1,6 +1,6 @@
 const md5 = require( "parcel-bundler/src/utils/md5" );
 const config = require( "parcel-bundler/src/utils/config" );
-const fs = require( "parcel-bundler/src/utils/fs" );
+const fs = require( "@parcel/fs" );
 const pipeSpawn = require( "parcel-bundler/src/utils/pipeSpawn" );
 
 const Asset = require( "parcel-bundler/src/Asset" );

--- a/CargoWebAsset.js
+++ b/CargoWebAsset.js
@@ -116,8 +116,6 @@ class CargoWebAsset extends Asset {
 
         const dir = path.dirname( await config.resolve( this.name, ["Cargo.toml"] ) );
         const args = [
-            "run",
-            cargo_web_command,
             "build",
             "--release",
             "--target",
@@ -133,7 +131,7 @@ class CargoWebAsset extends Asset {
             stdio: ["ignore", "pipe", "pipe"]
         };
 
-        const rust_build = spawn( "rustup", args, opts );
+        const rust_build = spawn( cargo_web_command, args, opts );
         const rust_build_process = rust_build.childProcess;
 
         let artifact_wasm = null;

--- a/CargoWebAsset.js
+++ b/CargoWebAsset.js
@@ -117,7 +117,6 @@ class CargoWebAsset extends Asset {
         const dir = path.dirname( await config.resolve( this.name, ["Cargo.toml"] ) );
         const args = [
             "run",
-            "nightly",
             cargo_web_command,
             "build",
             "--release",

--- a/CargoWebAsset.js
+++ b/CargoWebAsset.js
@@ -120,6 +120,7 @@ class CargoWebAsset extends Asset {
             "nightly",
             cargo_web_command,
             "build",
+            "--release",
             "--target",
             "wasm32-unknown-unknown",
             "--runtime",

--- a/CargoWebAsset.js
+++ b/CargoWebAsset.js
@@ -197,20 +197,10 @@ class CargoWebAsset extends Asset {
         return super.process();
     }
 
-    static async install_nightly() {
-        const rustup_show_output = await CargoWebAsset.exec( "rustup show" );
-        if( !rustup_show_output.includes( "nightly" ) ) {
-            await pipeSpawn( "rustup", ["update"] );
-            await pipeSpawn( "rustup", ["toolchain", "install", "nightly"] );
-        }
-    }
-
     async parse() {
         if ( !await CargoWebAsset.command_exists("rustup") ) {
             throw new Error("Rustup isn't installed. Visit https://rustup.rs/ for more info.");
         }
-
-        await CargoWebAsset.install_nightly();
 
         const cargo_web = await CargoWebAsset.cargo_web_command();
         const required_version = "^" + REQUIRED_CARGO_WEB.join(".");


### PR DESCRIPTION
Fix #11 by adding a `--release` argument to the cargo web command.

I also removed the requisite to use nightly Rust, as we can now compile to wasm using stable Rust. Therefore, the default toolchain will be used for each project, which closes #10.